### PR TITLE
Add 'destroy' method to cache to tear down Node properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function create(opts) {
   var interval = opts.interval || 1000 * 60;
   var cache = {};
 
-  setInterval(function () {
+  var cacheInterval = setInterval(function () {
     for (var key in cache) {
       if (cache[key].expire <= Date.now()) {
         delete cache[key];
@@ -33,5 +33,10 @@ module.exports = function create(opts) {
     get length() {
       return Object.keys(cache).length;
     },
+
+    destroy: function destroy() {
+      cache = {};
+      clearInterval(cacheInterval);
+    }
   };
 };

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ test('get-set', function (t) {
   var cache = Cache();
   cache.set('foo', 'bar');
   t.equals(cache.get('foo'), 'bar');
+  cache.destroy();
   t.end();
 });
 
@@ -15,6 +16,7 @@ test('expire', function (t) {
   cache.set('foo', 'bar');
   setTimeout(function () {
     t.equals(cache.get('foo'), null);
+    cache.destroy();
     t.end();
   }, 50);
 });
@@ -27,6 +29,15 @@ test('cleanup', function (t) {
   cache.set('foo', 'bar');
   setTimeout(function () {
     t.equals(cache.length, 0);
+    cache.destroy();
     t.end();
   }, 50);
-})
+});
+
+test('destroy', function (t) {
+  var cache = Cache()
+  cache.set('foo', 'bar');
+  cache.destroy();
+  t.equals(cache.length, 0);
+  t.end();
+});


### PR DESCRIPTION
Thanks for writing this. We ran into issues using it inside of a script, however, because there is no way to tear down the cache, which was blocking the Node process from terminating.

This PR adds that path and also fixes the test from hanging, too.